### PR TITLE
Remove unnecessary if statements. Add example md file

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,29 +78,22 @@ const createHtmlFiles = (filePath, fileType) => {
 
 const markdownToHtml = (param) => {
   // If Heading 1 to 6, turn into corresponding h1 to h6 tag
-  if (param.match(/^\s*(#{1,6}[^#]+$)/)) {
+  if (param.match(/^\s*#{1,6}[^#]+$/)) {
     const headerNum = param.match(/#/g).length
-    return Object({ type: `h${headerNum}`, content: param.replace(/^\s*(#{1,6})/, " ")});
+    return Object({ type: `h${headerNum}`, content: param.replace(/^\s*#{1,6}([^#]+)$/, "$1")});
   }
   else {
-    // If there is bold text wrap inside <b></b>
-    if(param.match(/\*\*([^\*]+)\*\*/)) {
-      param = param.replace(/\*\*([^\*]+)\*\*/g, "<b>$1</b>")
-    }
-    if(param.match(/__([^\*]+)__/)) {
-      param = param.replace(/__([^\*]+)__/g, "<b>$1</b>")
-    }
-    // If there is italic text wrap inside <i></i>
-    if(param.match(/\*([^\*]+)\*/)) {
-      param = param.replace(/\*([^\*]+)\*/g, "<i>$1</i>")
-    }
-    if(param.match(/_([^\*]+)_/)) {
-      param = param.replace(/_([^\*]+)_/g, "<i>$1</i>")
-    }
-    // If there is a link: [Title](http://example.com) turn into: <a href="http://example.com">Title</a>
-    if(param.match(/\[(.+)\]\((.+)\)/)) {
-      param = param.replace(/\[(.+)\]\((.+)\)/, '<a href="$2">$1</a>')
-    }
+    // Wrap bold text inside <b></b>
+    param = param.replace(/\*\*([^\*]+)\*\*/g, "<b>$1</b>")
+    param = param.replace(/__([^\*]+)__/g, "<b>$1</b>")
+
+    // Wrap italic text inside <i></i>
+    param = param.replace(/\*([^\*]+)\*/g, "<i>$1</i>")
+    param = param.replace(/_([^\*]+)_/g, "<i>$1</i>")
+
+    // Turn link: [Title](http://example.com) into: <a href="http://example.com">Title</a>
+    param = param.replace(/\[(.+)\]\((.+)\)/, '<a href="$2">$1</a>')
+
     return Object({ type: 'p', content: param});
   }
 }

--- a/textfiles/testFile.md
+++ b/textfiles/testFile.md
@@ -1,0 +1,65 @@
+# Javascript Static Site Generator (SSG)
+
+A Javascript command line program that converts .txt files into .html files. 
+
+## Implemented features 
+
+**Parsing titles** from .txt files => .html files to have h1 and title tags
+
+User can **specify output folder path**, instead of placing .html files in './dist' by default
+
+If **input path** is a folder, it will look for all .txt files in the folder and in subfolder(s)
+
+An *index.html* contains **links to other .html files** in folder.
+
+## Example:
+
+###### file.txt 
+
+```
+Silver Blaze
+
+
+I am afraid, Watson, that I shall have to go,” said Holmes, as we
+sat down together to our breakfast one morning.
+
+“Go! Where to?”
+
+“To Dartmoor; to King’s Pyland.”
+```
+
+will be converted to 
+
+###### file.html
+
+[Image of file.html](https://i.postimg.cc/8z9r8VMs/Screenshot-2021-09-22-160142.png)
+
+###### index.html for ./textfiles/
+
+[Image of index.html](https://i.ibb.co/9YVnN1y/Screenshot-2021-09-14-003724.png)
+
+## How to use:
+
+```
+node index.js -i ./textfiles/file.txt
+node index.js -i ./textfiles 
+node index.js -i ./textfiles -o ./outputFiles
+node index.js -i sometext.txt 
+```
+
+## Help 
+
+Usage: index [options]
+
+Options:
+  -V, --version            output the version number
+
+  -o, --output [file path]      specify a path for .html files output
+
+  -i, --input [file path]  (required) transform .txt files into .html files
+
+  -h, --help               display help for command
+
+## Demo Link
+
+https://tuenguyen2911.github.io/static-ssg-dps909/


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #12

## Description

This PR improves implementation of markdown support by removing unnecessary if statements in the `markdownToHtml()` function. It also makes minor changes to the regex expressions used to get the Headers.

Finally this PR adds a Markdown example file to the folder `./textfiles`
